### PR TITLE
refactor(Address): 주소 도메인을 객체 타입으로 변경

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,4 +49,4 @@
 ## ERD
 <br>
 
-![ERD](https://github.com/hellmir/delivery/assets/128391669/3ef77942-e45f-4530-a99d-e005308feba0)
+![ERD](https://github.com/hellmir/delivery/assets/128391669/a1ca3f03-8164-45fa-93e0-f72e7fba45dc)

--- a/src/main/java/personal/delivery/member/MemberController.java
+++ b/src/main/java/personal/delivery/member/MemberController.java
@@ -17,24 +17,23 @@ import personal.delivery.member.service.MemberService;
 public class MemberController {
 
     private final MemberService memberService;
-//    private final PasswordEncoder passwordEncoder;
 
     @PostMapping("sellers")
     public ResponseEntity<MemberResponseDto> signUpSeller(@RequestBody MemberDto memberDto) {
 
-//        MemberResponseDto memberResponseDto = memberService.createMember(memberDto, passwordEncoder);
         MemberResponseDto memberResponseDto = memberService.createSeller(memberDto);
 
         return ResponseEntity.status(HttpStatus.OK).body(memberResponseDto);
+
     }
 
     @PostMapping("customers")
     public ResponseEntity<MemberResponseDto> signUpCustomer(@RequestBody MemberDto memberDto) {
 
-//        MemberResponseDto memberResponseDto = memberService.createMember(memberDto, passwordEncoder);
         MemberResponseDto memberResponseDto = memberService.createCustomer(memberDto);
 
         return ResponseEntity.status(HttpStatus.OK).body(memberResponseDto);
+
     }
 
 }

--- a/src/main/java/personal/delivery/member/domain/Address.java
+++ b/src/main/java/personal/delivery/member/domain/Address.java
@@ -1,0 +1,27 @@
+package personal.delivery.member.domain;
+
+import jakarta.persistence.Embeddable;
+import lombok.Getter;
+
+@Embeddable
+@Getter
+public class Address {
+
+    private String city;
+    private String street;
+    private String zipcode;
+    private String detailedAddress;
+
+    protected Address() {
+    }
+
+    public Address(String city, String street, String zipcode, String detailedAddress) {
+
+        this.city = city;
+        this.street = street;
+        this.zipcode = zipcode;
+        this.detailedAddress = detailedAddress;
+
+    }
+
+}

--- a/src/main/java/personal/delivery/member/domain/Member.java
+++ b/src/main/java/personal/delivery/member/domain/Member.java
@@ -1,10 +1,11 @@
-package personal.delivery.member;
+package personal.delivery.member.domain;
 
 import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import personal.delivery.constant.Role;
+import personal.delivery.member.domain.Address;
 
 import java.time.LocalDateTime;
 
@@ -28,8 +29,8 @@ public class Member {
     @Column(nullable = false, length = 20)
     private String password;
 
-    @Column(length = 50)
-    private String address;
+    @Embedded
+    private Address address;
 
     @Enumerated(EnumType.STRING)
     private Role role;
@@ -38,13 +39,16 @@ public class Member {
     LocalDateTime updateTime;
 
     @Builder
-    public Member(String name, String email, String password, String address, Role role,
+    public Member(String name, String email, String password, Address address, Role role,
                   LocalDateTime registrationTime, LocalDateTime updateTime) {
 
         this.name = name;
         this.email = email;
         this.password = password;
-        this.address = address;
+
+        Address inputAddress = new Address(address.getCity(), address.getStreet(), address.getZipcode(), address.getDetailedAddress());
+        this.address = inputAddress;
+
         this.role = role;
         this.registrationTime = registrationTime;
         this.updateTime = updateTime;

--- a/src/main/java/personal/delivery/member/dto/MemberDto.java
+++ b/src/main/java/personal/delivery/member/dto/MemberDto.java
@@ -1,6 +1,7 @@
 package personal.delivery.member.dto;
 
 import lombok.Data;
+import personal.delivery.member.domain.Address;
 
 @Data
 public class MemberDto {
@@ -8,6 +9,6 @@ public class MemberDto {
     private String name;
     private String email;
     private String password;
-    private String address;
+    private Address address;
 
 }

--- a/src/main/java/personal/delivery/member/dto/MemberResponseDto.java
+++ b/src/main/java/personal/delivery/member/dto/MemberResponseDto.java
@@ -2,6 +2,7 @@ package personal.delivery.member.dto;
 
 import lombok.Data;
 import personal.delivery.constant.Role;
+import personal.delivery.member.domain.Address;
 
 import java.time.LocalDateTime;
 
@@ -10,7 +11,7 @@ public class MemberResponseDto {
 
     private String name;
     private String email;
-    private String address;
+    private Address address;
     private Role role;
 
     private LocalDateTime registrationTime;


### PR DESCRIPTION
## 변경사항
- 주소 도메인을 객체 타입으로 변경하고,  city, street, zipcode, detailedAddress 속성을 추가

## API 동작 테스트
![2023-06-25 (4)](https://github.com/hellmir/delivery/assets/128391669/c682c3fc-5b39-4a94-8805-09b328b80707)

## ERD 업데이트
![ERD](https://github.com/hellmir/delivery/assets/128391669/a1ca3f03-8164-45fa-93e0-f72e7fba45dc)