### PR TITLE
update(StockStatus): 재료 소진 여부의 타입을 enum으로 변경

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,4 +57,4 @@
 
 ## ERD
 
-![ERD](https://github.com/hellmir/delivery/assets/128391669/c73f4217-025a-4933-b8c1-ea6568d9f2da)
+![ERD](https://github.com/hellmir/delivery/assets/128391669/9be23c84-53f9-4ff8-99f6-8f04ee35312a)

--- a/README.md
+++ b/README.md
@@ -57,4 +57,4 @@
 
 ## ERD
 
-![ERD](https://github.com/hellmir/delivery/assets/128391669/9be23c84-53f9-4ff8-99f6-8f04ee35312a)
+![ERD](https://github.com/hellmir/delivery/assets/128391669/133e808f-cffe-4b52-af2a-dc3ff38d98b6)

--- a/src/main/java/personal/delivery/constant/StockStatus.java
+++ b/src/main/java/personal/delivery/constant/StockStatus.java
@@ -1,0 +1,5 @@
+package personal.delivery.constant;
+
+public enum StockStatus {
+    AVAILABLE, OUT_OF_STOCK
+}

--- a/src/main/java/personal/delivery/menu/Menu.java
+++ b/src/main/java/personal/delivery/menu/Menu.java
@@ -4,6 +4,7 @@ import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import personal.delivery.constant.StockStatus;
 import personal.delivery.exception.OutOfStockException;
 
 import java.time.LocalDateTime;
@@ -32,6 +33,8 @@ public class Menu {
     @Column
     private Integer stock;
 
+    private StockStatus stockStatus;
+
     @Column(length = 10)
     private String flavor;
 
@@ -44,7 +47,7 @@ public class Menu {
     @Column(length = 10)
     private String foodType;
 
-    private Boolean popularMenu;
+    private Boolean isPopularMenu;
     private List<String> menuOption;
 
     private LocalDateTime registrationTime;
@@ -52,8 +55,8 @@ public class Menu {
 
     @Builder
     public Menu(Long id, String name, Integer price, Integer salesRate, Integer stock,
-                String flavor, Integer portions, Integer cookingTime, String menuType,
-                String foodType, Boolean popularMenu, List<String> menuOption,
+                String flavor, Integer portions, Integer cookingTime,
+                String menuType, String foodType, Boolean isPopularMenu, List<String> menuOption,
                 LocalDateTime registrationTime, LocalDateTime updateTime) {
 
         this.id = id;
@@ -61,12 +64,21 @@ public class Menu {
         this.price = price;
         this.salesRate = salesRate;
         this.stock = stock;
+
+        if (this.stock > 0) {
+            stockStatus = StockStatus.AVAILABLE;
+        } else if (this.stock == 0) {
+            stockStatus = StockStatus.OUT_OF_STOCK;
+        } else {
+            throw new OutOfStockException("재료 최소 수량 : 0");
+        }
+
         this.flavor = flavor;
         this.portions = portions;
         this.cookingTime = cookingTime;
         this.menuType = menuType;
         this.foodType = foodType;
-        this.popularMenu = popularMenu;
+        this.isPopularMenu = isPopularMenu;
         this.menuOption = menuOption;
         this.registrationTime = registrationTime;
         this.updateTime = updateTime;
@@ -85,7 +97,7 @@ public class Menu {
         name.replace("(인기메뉴)", "");
 
         if (salesRate >= 100) {
-            popularMenu = true;
+            isPopularMenu = true;
             name += "(인기메뉴)";
         }
 
@@ -94,11 +106,11 @@ public class Menu {
     private void adjustStockState(int presentStock) {
 
         if (presentStock == 0) {
-            name += "(재료 소진)";
+            stockStatus = StockStatus.OUT_OF_STOCK;
         }
 
         if (presentStock > 0) {
-            name.replace("(재료 소진)", "");
+            stockStatus = StockStatus.AVAILABLE;
         }
 
         if (presentStock < 0) {

--- a/src/main/java/personal/delivery/menu/dto/MenuResponseDto.java
+++ b/src/main/java/personal/delivery/menu/dto/MenuResponseDto.java
@@ -3,6 +3,7 @@ package personal.delivery.menu.dto;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import personal.delivery.constant.StockStatus;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -17,12 +18,13 @@ public class MenuResponseDto {
     private int price;
     private int salesRate;
     private int stock;
+    private StockStatus stockStatus;
     private String flavor;
     private int portions;
     private int cookingTime;
     private String menuType;
     private String foodType;
-    private boolean popularMenu;
+    private boolean isPopularMenu;
     private List<String> menuOption;
 
     private LocalDateTime registrationTime;


### PR DESCRIPTION
## 변경사항
- 재료 소진 여부를 enum 타입(AVAILABLE, OUT_OF_STOCK)으로 표시하도록 변경
- popularMenu의 변수명을 isPopularMenu로 변경

## API 동작 테스트
- 메뉴 등록(재료 없음)
![2023-07-03 (10)](https://github.com/hellmir/delivery/assets/128391669/cade1dda-2bd3-4adc-b39b-ff8703363c48)

- 메뉴 수정(재료 추가)
![2023-07-03 (11)](https://github.com/hellmir/delivery/assets/128391669/eeff8cd6-7328-4a85-a184-f41632e0b491)

- 메뉴 등록(재료 있음)
![2023-07-03 (16)](https://github.com/hellmir/delivery/assets/128391669/d9540a85-cc64-4282-941f-2335443942d2)

- 메뉴 주문(재료 소진)
![2023-07-03 (17)](https://github.com/hellmir/delivery/assets/128391669/28349605-1362-4051-90ab-5b3989e3b730)

- 메뉴 조회(재료 소진)
![2023-07-03 (18)](https://github.com/hellmir/delivery/assets/128391669/9d890151-10d7-4fb1-a5bd-0538ab0fb1dc)

## ERD 업데이트
![ERD](https://github.com/hellmir/delivery/assets/128391669/133e808f-cffe-4b52-af2a-dc3ff38d98b6)