### PR TITLE
fix(Access level): 일부 Entity 기본 생성자의 접근 등급을 PROTECTED로 변경

### DIFF
--- a/src/main/java/personal/delivery/cart/service/CartService.java
+++ b/src/main/java/personal/delivery/cart/service/CartService.java
@@ -3,7 +3,7 @@ package personal.delivery.cart.service;
 import personal.delivery.cart.dto.CartMenuDto;
 import personal.delivery.cart.dto.CartMenuResponseDto;
 import personal.delivery.cart.entity.Cart;
-import personal.delivery.member.domain.Member;
+import personal.delivery.member.eneity.Member;
 
 public interface CartService {
 

--- a/src/main/java/personal/delivery/cart/service/CartServiceImpl.java
+++ b/src/main/java/personal/delivery/cart/service/CartServiceImpl.java
@@ -10,7 +10,7 @@ import personal.delivery.cart.entity.CartMenu;
 import personal.delivery.cart.repository.CartMenuRepository;
 import personal.delivery.cart.repository.CartRepository;
 import personal.delivery.config.BeanConfiguration;
-import personal.delivery.member.domain.Member;
+import personal.delivery.member.eneity.Member;
 import personal.delivery.member.repository.MemberRepository;
 import personal.delivery.menu.Menu;
 import personal.delivery.menu.repository.MenuRepository;

--- a/src/main/java/personal/delivery/config/BeanConfiguration.java
+++ b/src/main/java/personal/delivery/config/BeanConfiguration.java
@@ -4,7 +4,7 @@ import org.modelmapper.ModelMapper;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import personal.delivery.cart.entity.Cart;
-import personal.delivery.member.domain.Member;
+import personal.delivery.member.eneity.Member;
 import personal.delivery.menu.Menu;
 import personal.delivery.order.entity.Order;
 

--- a/src/main/java/personal/delivery/constant/StockStatus.java
+++ b/src/main/java/personal/delivery/constant/StockStatus.java
@@ -1,5 +1,5 @@
 package personal.delivery.constant;
 
 public enum StockStatus {
-    AVAILABLE, OUT_OF_STOCK
+    AVAILABLE, LOW_STOCK, OUT_OF_STOCK
 }

--- a/src/main/java/personal/delivery/member/dto/MemberDto.java
+++ b/src/main/java/personal/delivery/member/dto/MemberDto.java
@@ -1,7 +1,7 @@
 package personal.delivery.member.dto;
 
 import lombok.Data;
-import personal.delivery.member.domain.Address;
+import personal.delivery.member.eneity.Address;
 
 @Data
 public class MemberDto {

--- a/src/main/java/personal/delivery/member/dto/MemberResponseDto.java
+++ b/src/main/java/personal/delivery/member/dto/MemberResponseDto.java
@@ -2,7 +2,7 @@ package personal.delivery.member.dto;
 
 import lombok.Data;
 import personal.delivery.constant.Role;
-import personal.delivery.member.domain.Address;
+import personal.delivery.member.eneity.Address;
 
 import java.time.LocalDateTime;
 

--- a/src/main/java/personal/delivery/member/eneity/Address.java
+++ b/src/main/java/personal/delivery/member/eneity/Address.java
@@ -1,4 +1,4 @@
-package personal.delivery.member.domain;
+package personal.delivery.member.eneity;
 
 import jakarta.persistence.Embeddable;
 import lombok.Getter;

--- a/src/main/java/personal/delivery/member/eneity/Member.java
+++ b/src/main/java/personal/delivery/member/eneity/Member.java
@@ -1,17 +1,17 @@
-package personal.delivery.member.domain;
+package personal.delivery.member.eneity;
 
 import jakarta.persistence.*;
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import personal.delivery.constant.Role;
-import personal.delivery.member.domain.Address;
 
 import java.time.LocalDateTime;
 
 @Entity
 @Getter
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "member")
 public class Member {
 

--- a/src/main/java/personal/delivery/member/repository/MemberRepository.java
+++ b/src/main/java/personal/delivery/member/repository/MemberRepository.java
@@ -1,7 +1,7 @@
 package personal.delivery.member.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
-import personal.delivery.member.domain.Member;
+import personal.delivery.member.eneity.Member;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
 

--- a/src/main/java/personal/delivery/member/service/MemberService.java
+++ b/src/main/java/personal/delivery/member/service/MemberService.java
@@ -1,6 +1,6 @@
 package personal.delivery.member.service;
 
-import personal.delivery.member.domain.Member;
+import personal.delivery.member.eneity.Member;
 import personal.delivery.member.dto.MemberDto;
 import personal.delivery.member.dto.MemberResponseDto;
 

--- a/src/main/java/personal/delivery/member/service/MemberServiceImpl.java
+++ b/src/main/java/personal/delivery/member/service/MemberServiceImpl.java
@@ -5,7 +5,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import personal.delivery.config.BeanConfiguration;
 import personal.delivery.constant.Role;
-import personal.delivery.member.domain.Member;
+import personal.delivery.member.eneity.Member;
 import personal.delivery.member.dto.MemberDto;
 import personal.delivery.member.dto.MemberResponseDto;
 import personal.delivery.member.repository.MemberRepository;

--- a/src/main/java/personal/delivery/menu/Menu.java
+++ b/src/main/java/personal/delivery/menu/Menu.java
@@ -65,8 +65,10 @@ public class Menu {
         this.salesRate = salesRate;
         this.stock = stock;
 
-        if (this.stock > 0) {
+        if (this.stock > 10) {
             stockStatus = StockStatus.AVAILABLE;
+        } else if (this.stock > 0) {
+            stockStatus = StockStatus.LOW_STOCK;
         } else if (this.stock == 0) {
             stockStatus = StockStatus.OUT_OF_STOCK;
         } else {
@@ -109,8 +111,10 @@ public class Menu {
             stockStatus = StockStatus.OUT_OF_STOCK;
         }
 
-        if (presentStock > 0) {
+        if (presentStock > 10) {
             stockStatus = StockStatus.AVAILABLE;
+        } else if (presentStock > 0) {
+            stockStatus = StockStatus.LOW_STOCK;
         }
 
         if (presentStock < 0) {

--- a/src/main/java/personal/delivery/order/entity/Order.java
+++ b/src/main/java/personal/delivery/order/entity/Order.java
@@ -2,11 +2,12 @@ package personal.delivery.order.entity;
 
 
 import jakarta.persistence.*;
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import personal.delivery.constant.OrderStatus;
-import personal.delivery.member.domain.Member;
+import personal.delivery.member.eneity.Member;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -14,7 +15,7 @@ import java.util.List;
 
 @Entity
 @Getter
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "orders")
 public class Order {
 

--- a/src/main/java/personal/delivery/order/service/OrderService.java
+++ b/src/main/java/personal/delivery/order/service/OrderService.java
@@ -1,6 +1,6 @@
 package personal.delivery.order.service;
 
-import personal.delivery.member.domain.Member;
+import personal.delivery.member.eneity.Member;
 import personal.delivery.order.dto.OrderDto;
 import personal.delivery.order.dto.OrderResponseDto;
 import personal.delivery.order.entity.Order;

--- a/src/main/java/personal/delivery/order/service/OrderServiceImpl.java
+++ b/src/main/java/personal/delivery/order/service/OrderServiceImpl.java
@@ -7,7 +7,7 @@ import org.springframework.transaction.annotation.Transactional;
 import personal.delivery.config.BeanConfiguration;
 import personal.delivery.constant.OrderStatus;
 import personal.delivery.constant.Role;
-import personal.delivery.member.domain.Member;
+import personal.delivery.member.eneity.Member;
 import personal.delivery.member.repository.MemberRepository;
 import personal.delivery.menu.Menu;
 import personal.delivery.menu.repository.MenuRepository;


### PR DESCRIPTION
## 변경사항
- 기본 생성자를 통한 잘못된 객체 생성을 방지하기 위해 일부 Entity의 접근 등급을 PROTECTED로 변경
- Member 클래스가 포함된 domain 패키지에 현재 entity만 존재하고 Order 클래스가 포함된 패키지의  이름이 entity이므로, 적합성과 통일성을 고려해 domain 패키지의 이름을 entity로 변경